### PR TITLE
added vlookup formula, fixed mixed args in formulas

### DIFF
--- a/src/core/formula.js
+++ b/src/core/formula.js
@@ -11,7 +11,7 @@
  * @property {function} render
  */
 import { tf } from '../locale/locale';
-import { numberCalc } from './helper';
+import { numberCalc, mapValuesToMatrix } from './helper';
 
 /** @type {Formula[]} */
 const baseFormulas = [
@@ -59,6 +59,34 @@ const baseFormulas = [
     key: 'CONCATENATE',
     title: tf('formula.concatenate'),
     render: ary => ary.join(''),
+  },
+  {
+    key: 'VLOOKUP',
+    title: tf('formula.vlookup'),
+    render: (ary, matrixMapping) => {
+      const [loopupVal, ...values] = ary;
+      const [, ...mapping] = matrixMapping;
+
+      let colIndex = 0;
+
+      if (Number.isNaN(parseInt(mapping.at(-1), 10))) {
+        return '#N/A';
+      }
+
+      const index = values.pop();
+
+      if (index === 0) {
+        return '#VALUE!';
+      }
+
+      colIndex = index - 1;
+      mapping.pop();
+
+      const matrix = mapValuesToMatrix(mapping, values);
+
+      const indexOfElm = matrix[0].lastIndexOf(loopupVal);
+      return indexOfElm !== -1 ? matrix[colIndex][indexOfElm] : '#N/A';
+    },
   },
   {
     key: 'DIVIDE',

--- a/src/core/formula.js
+++ b/src/core/formula.js
@@ -84,7 +84,7 @@ const baseFormulas = [
 
       const matrix = mapValuesToMatrix(mapping, values);
 
-      const indexOfElm = matrix[0].lastIndexOf(loopupVal);
+      const indexOfElm = matrix[0].indexOf(loopupVal);
       return indexOfElm !== -1 ? matrix[colIndex][indexOfElm] : '#N/A';
     },
   },

--- a/src/core/helper.js
+++ b/src/core/helper.js
@@ -133,6 +133,19 @@ export function numberCalc(type, a1, a2) {
   return ret.toFixed(Math.max(al1, al2));
 }
 
+export function mapValuesToMatrix(mapping, values) {
+  const chunks = [];
+  for (let i = 0; i < mapping.length; i += 1) {
+    const last = chunks[chunks.length - 1];
+    if (!last || mapping[i - 1].charAt(0) !== mapping[i].charAt(0)) {
+      chunks.push([values[i]]);
+    } else {
+      last.push(values[i]);
+    }
+  }
+  return chunks;
+}
+
 export default {
   cloneDeep,
   merge: (...sources) => mergeDeep({}, ...sources),
@@ -144,4 +157,5 @@ export default {
   rangeReduceIf,
   deleteProperty,
   numberCalc,
+  mapValuesToMatrix,
 };

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -73,6 +73,7 @@ export default {
     concat: 'Concat',
     concatenate: 'Concatenate',
     divide: 'Divide',
+    vlookup: 'Vlookup',
   },
   validation: {
     required: 'it must be required',


### PR DESCRIPTION
formulae should work with mixed args (single and ranges) either separated by comma or semicolon, e.g. SUM(A1;B2:C3)
VLOOKUP formula implemented (WITHOUT cross table support)