### PR TITLE
Speed up history operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bergfreunde/x-data-spreadsheet",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
     "opencollective": "^1.0.3",
     "opencollective-postinstall": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bergfreunde/x-data-spreadsheet",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "description": "a javascript xpreadsheet",
   "types": "src/index.d.ts",
   "main": "src/index.js",

--- a/src/core/history.js
+++ b/src/core/history.js
@@ -1,7 +1,4 @@
-// import helper from '../helper';
-// import isEqual from 'lodash/isEqual';
-import cloneDeep from 'lodash/cloneDeep';
-import merge from 'lodash/merge';
+import helper from './helper';
 
 export default class History {
   constructor() {
@@ -11,7 +8,7 @@ export default class History {
 
   init(data) {
     if (data) {
-      this.initialState = cloneDeep(data);
+      this.initialState = JSON.stringify(data);
     }
     this.undoItems = [];
     this.redoItems = [];
@@ -20,7 +17,7 @@ export default class History {
   add([data, selector]) {
     const [state] = this.undoItems.at(-1) || [{}];
     this.undoItems.push(
-      [merge({}, state, data), selector],
+      [this.merge(data, state), selector],
     );
     this.redoItems = [];
   }
@@ -40,7 +37,7 @@ export default class History {
       redoItems.push(currentState);
       const [state] = undoItems.at(-1) || [{}];
       cb(
-        [merge({}, this.initialState, state), currentState[1]],
+        [this.merge(state), currentState[1]],
       );
     }
   }
@@ -51,7 +48,7 @@ export default class History {
       const [state, selector] = redoItems.pop();
       undoItems.push([state, selector]);
       cb(
-        [merge({}, this.initialState, state), selector],
+        [this.merge(state), selector],
       );
     }
   }
@@ -87,5 +84,10 @@ export default class History {
       return set;
     }
     return [];
+  }
+
+  merge(newState, oldState) {
+    const initial = oldState || JSON.parse(this.initialState);
+    return helper.merge(initial, newState);
   }
 }


### PR DESCRIPTION
reduces time to complete operations (add/undo/redo) by round 40%

quick benchmarking with 100k rows (x 50 Columns)
before
undo: 2924.723876953125 ms
undo: 2517.576904296875 ms
undo: 2860.81005859375 ms
undo: 2541.362060546875 ms
redo: 2683.650146484375 ms
redo: 2658.299072265625 ms
redo: 2681.257080078125 ms
redo: 2728.52099609375 ms

after
undo: 1793.409912109375 ms
undo: 1363.796875 ms
undo: 1396.85791015625 ms
undo: 1488.695068359375 ms
redo: 1727.51513671875 ms
redo: 1397.403076171875 ms
redo: 1425.426025390625 ms
redo: 1458.501953125 ms