### PR TITLE
Feature: only insert cols and rows at end

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bergfreunde/x-data-spreadsheet",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bergfreunde/x-data-spreadsheet",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "description": "a javascript xpreadsheet",
   "types": "src/index.d.ts",
   "main": "src/index.js",

--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -1,4 +1,3 @@
-/* global window */
 /* eslint-env browser */
 import { h } from './element';
 import {
@@ -85,7 +84,7 @@ function selectorSet(multiple, ri, ci, indexesUpdated = true, moving = false) {
   if (ri === -1 && ci === -1) return;
   const {
     table, selector, toolbar, data,
-    contextMenu,
+    contextMenu, insertAtEnd,
   } = this;
   const cell = data.getCell(ri, ci);
   if (multiple) {
@@ -109,11 +108,22 @@ function selectorSet(multiple, ri, ci, indexesUpdated = true, moving = false) {
   if (ri === -1 || (sci === eci && sri !== eri)) {
     mode = 'col';
   }
+
   if (ci === -1 || (sri === eri && sci !== eci)) {
     mode = 'row';
   }
 
-  contextMenu.setMode(mode);
+  const isLast = { row: false, col: false };
+
+  if (sci === data.cols.len - 1) {
+    isLast.col = true;
+  }
+
+  if (sri === data.rows.len - 1) {
+    isLast.row = true;
+  }
+
+  contextMenu.setMode(mode, insertAtEnd, isLast);
   toolbar.reset();
   table.render();
 }
@@ -1030,7 +1040,8 @@ function find(val, idx, replace, replaceWith = '', matchCase = false, matchCellC
 }
 
 export default class Sheet {
-  constructor(targetEl, idx, dataSet) {
+  constructor(targetEl, idx, dataSet, insertAtEnd = false) {
+    this.insertAtEnd = insertAtEnd;
     this.container = targetEl;
     this.eventMap = createEventEmitter();
     const { view, showToolbar, showContextmenu } = dataSet[idx].settings;

--- a/src/core/data_proxy.js
+++ b/src/core/data_proxy.js
@@ -1012,8 +1012,11 @@ export default class DataProxy {
     const { selector } = this;
     this.changeData(() => {
       const deletedCells = this.rows.deleteCells(selector.range, what);
+      if (!deletedCells) {
+        return null;
+      }
       let mergesChanged = false;
-      if (what === 'all' || what === 'format') {
+      if (what === 'all') {
         this.merges.deleteWithin(selector.range);
         mergesChanged = true;
       }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,6 +45,7 @@ declare module '@bergfreunde/x-data-spreadsheet' {
         italic: false;
       };
     };
+    insertAtEnd?: boolean;
   }
 
   export type CELL_SELECTED = 'cell-selected';

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-/* global window, document */
+/* global document */
 import { h } from './component/element';
 import DataProxy from './core/data_proxy';
 import Sheet from './component/sheet';
@@ -34,7 +34,7 @@ class Spreadsheet {
       .on('contextmenu', evt => evt.preventDefault());
     // create canvas element
     targetEl.appendChild(rootEl.el);
-    this.sheet = new Sheet(rootEl, this.dataIndex, this.dataSet);
+    this.sheet = new Sheet(rootEl, this.dataIndex, this.dataSet, this.options.insertAtEnd);
     if (this.bottombar !== null) {
       rootEl.child(this.bottombar.el);
     }

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -42,6 +42,7 @@ export default {
     deleteColumn: 'Delete column',
     deleteCell: 'Delete cell',
     deleteCellText: 'Delete cell text',
+    deleteCellFormat: 'Delete cell format',
     validation: 'Data validations',
     cellprintable: 'Enable export',
     cellnonprintable: 'Disable export',


### PR DESCRIPTION
new Spreadsheet('#selector', { insertAtEnd: true })
only insert col to the right of last col and row below last row 
delete row and col would only work on last row and col respectively
also improved undo/redo